### PR TITLE
add details in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ $ npm i koa-await-breakpoint-jaeger --save
 
 ```sh
 $ docker run -d -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
+$ docker run -p27017:27017 -d mongo
 $ node example/app
 $ curl -XPOST localhost:3000/users
 ```
+
+open jaeger-query default url `http://localhost:16686/search` 
 
 ### Usage
 


### PR DESCRIPTION
Example koa code use db at local mongo:27017.
And the jaeger-query dashborad url.